### PR TITLE
Fix exception raised when subscription returns a nil payment intent

### DIFF
--- a/lib/bling/customers.ex
+++ b/lib/bling/customers.ex
@@ -427,6 +427,8 @@ defmodule Bling.Customers do
     session.url
   end
 
+  defp maybe_confirm(%{latest_invoice: %{payment_intent: nil}}, _return_url), do: {:ok, nil}
+
   defp maybe_confirm(%{status: "incomplete"} = stripe_subscription, return_url) do
     Stripe.PaymentIntent.confirm(stripe_subscription.latest_invoice.payment_intent, %{
       return_url: return_url


### PR DESCRIPTION
Closes #7

Handles case when `payment_intent` is `nil`.  This can happen if a "forever free" coupon is used.