### PR TITLE
include CSRF token and correct fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,10 +332,13 @@ if (error) {
   return;
 }
 
-const response = await fetch({
-  method: 'post',
-  url: '/billing/user/1/payment-method',
+const response = await fetch(`/billing/user/1/payment-method`, {
+  method: "post",
   body: JSON.stringify({ payment_method_id: setupIntent.payment_method }),
+  headers: {
+    "X-CSRF-Token": csrfToken,
+    "Content-Type": "application/json",
+  },
 });
 ```
 


### PR DESCRIPTION
The example is malformed, fetch requires the first parameter to be the url, and Phoenix will ask the csrf token to be included.